### PR TITLE
ResumoWAP2-ARTIGODEPESQUISA

### DIFF
--- a/Isabelle Borges S_Vieira/Subredes4/s/Subredes_4
+++ b/Isabelle Borges S_Vieira/Subredes4/s/Subredes_4
@@ -1,0 +1,53 @@
+1. Hosts: (2^n)-2 = 30 → n = 5, ou seja, 5 zeros;
+
+11100000 → 2^5 +2^6+2^7 = 32+64+128 = 224
+
+∆= 256-224 = 32 bits;
+
+Está variando o último com três uns e cinco zeros, logo 8+8+8+3 = 27;
+
+A máscara é /27.
+
+R= Letra A.
+
+2. ∆= 256-240 = 16;
+
+R = Letra A.
+
+3. (2^n)-2>=60 → n = 6;
+
+11000000 → 2^6+2^7 = 192;
+
+∆= 64;
+
+8+8+8+2, logo é /26.
+
+R= Letra B.
+
+4. 11111000-->248
+∆ = 256-248 = 8;
+
+R= Letra D;
+
+5. É /27, logo sabe-se que têm 5 zeros.
+11100000-->224
+∆= 256-224 = 32 bits;
+R= Letra C.
+
+6. 11110000
+(2^12)-2 >= n
+4096-2 >= n ---> 4094;
+R= Letra A.
+
+7.  Sabe-se que /23 têm 9 zeros. 
+11111110-->254
+∆= 256-254 = 2;
+R= Letra B.
+
+8. 11111100-->252;
+∆= 256-252 = 4;
+A e E são de rede, C é de broadcast;
+Restam B e D, que são de host.
+
+R= Letra B e D.
+

--- a/Isabelle Borges/SUBREDES_4
+++ b/Isabelle Borges/SUBREDES_4
@@ -1,0 +1,53 @@
+1. Hosts: (2^n)-2 = 30 → n = 5, ou seja, 5 zeros;
+
+11100000 → 2^5 +2^6+2^7 = 32+64+128 = 224
+
+∆= 256-224 = 32 bits;
+
+Está variando o último com três uns e cinco zeros, logo 8+8+8+3 = 27;
+
+A máscara é /27.
+
+R= Letra A.
+
+2. ∆= 256-240 = 16;
+
+R = Letra A.
+
+3. (2^n)-2>=60 → n = 6;
+
+11000000 → 2^6+2^7 = 192;
+
+∆= 64;
+
+8+8+8+2, logo é /26.
+
+R= Letra B.
+
+4. 11111000-->248
+∆ = 256-248 = 8;
+
+R= Letra D;
+
+5. É /27, logo sabe-se que têm 5 zeros.
+11100000-->224
+∆= 256-224 = 32 bits;
+R= Letra C.
+
+6. 11110000
+(2^12)-2 >= n
+4096-2 >= n ---> 4094;
+R= Letra A.
+
+7.  Sabe-se que /23 têm 9 zeros. 
+11111110-->254
+∆= 256-254 = 2;
+R= Letra B.
+
+8. 11111100-->252;
+∆= 256-252 = 4;
+A e E são de rede, C é de broadcast;
+Restam B e D, que são de host.
+
+R= Letra B e D.
+


### PR DESCRIPTION
A descoberta das falhas do WPA2, feita pelo pesquisador da empresa belga de segurança, Mathy Vanhoef, é apresentada em forma de um projeto de pesquisa e sua demonstração foi feita a partir de um ataque contra um smartphone Android, sendo o principal ataque feito contra o handshake de quatro vias do WPA2. 
Na pesquisa, é citada a vulnerabilidade dos "SOs", com foque no Linux e no Android por serem facilmente "enganados" para uma nova instalação de chave de criptografia. Também é visto que o invasor pode descriptografar uma variedades de dados da vítima; e principais ataques quando se tem uma reinstalação, utilizando exemplo real contra o handshake de quatro vias.
A decodificação de pacotes, como pode-se analisar ao longo da leitura, é possível porque um ataque de reinstalação de chave faz com que os nonces de transmissão sejam redefinidos para zero.
"A capacidade de descriptografar pacotes pode ser usada para descriptografar pacotes TCP SYN. Isso permite que um adversário obtenha os números de seqüência TCP de uma conexão e remova as conexões TCP. Como resultado, mesmo que o WPA2 seja usado, o adversário agora pode executar um dos ataques mais comuns contra redes Wi-Fi abertas: injetando dados mal-intencionados em conexões HTTP não criptografadas" - diz um trecho do artigo, disponibilizado no krackattacks.com.
Uma solução que pode ser vista na pesquisa é o aumento da rigorosidade nas inspeções sobre o implemento de protocolos, mobilizando a comunidade acadêmica para tal tarefa e fazendo parcerias com pesquisadores da área.
Essa pesquisa desempenha um papel de grande importância na vida social, visto que, busca mostrar que nada é totalmente seguro no mundo virtual e que a cautela é uma medida fundamental para dificultar que as pessoas sofram ataques.